### PR TITLE
Add labels required by the Red Hat EC policy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,4 +22,17 @@ LABEL org.opencontainers.image.description="CLI tool and library for generating 
 LABEL org.opencontainers.image.vendor="Red Hat, Inc."
 LABEL org.opencontainers.image.licenses="Apache-2.0"
 
+# required per https://github.com/release-engineering/rhtap-ec-policy/blob/main/data/rule_data.yml
+# TODO: set up in Bugzilla
+LABEL com.redhat.component="syft"
+LABEL version="0.89.0"
+# TODO: document the need to bump this on every re-release of the same version
+LABEL release="1"
+LABEL name="syft"
+LABEL description="CLI tool and library for generating a Software Bill of Materials from container images and filesystems"
+LABEL io.k8s.description="CLI tool and library for generating a Software Bill of Materials from container images and filesystems"
+LABEL vendor="Red Hat, Inc."
+LABEL url="https://github.com/redhat-appstudio/rh-syft"
+LABEL distribution-scope="public"
+
 ENTRYPOINT ["/syft"]

--- a/README.md
+++ b/README.md
@@ -42,9 +42,12 @@ Check if there is a new upstream version to update to:
 make check-release
 ```
 
-If the downstream is behind upstream, it's time to update. Start by bumping the
-`CURRENT_RELEASE` in the Makefile and commiting the change (best done on a new branch
-dedicated to the [midstream update](#updating-the-midstream).
+If the downstream is behind upstream, it's time to update. First step:
+
+* Bump the `CURRENT_RELEASE` in the Makefile
+* Bump the `version` label in the Dockerfile
+* Commit the changes (best done on a new branch dedicated to the
+  [midstream update](#updating-the-midstream))
 
 <!-- TODO: Do we need to update one by one? Can we skip versions?
      Probably don't jump more than one minor release at a time. -->


### PR DESCRIPTION
And document the need to bump the `version` label when updating to a new upstream release