### PR TITLE
Use UBI 9 micro as the final base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,6 +32,8 @@ LABEL version="0.105.0"
 # TODO: document the need to bump this on every re-release of the same version
 LABEL release="1"
 LABEL name="syft"
+LABEL io.k8s.display-name="syft"
+LABEL summary="syft"
 LABEL description="CLI tool and library for generating a Software Bill of Materials from container images and filesystems"
 LABEL io.k8s.description="CLI tool and library for generating a Software Bill of Materials from container images and filesystems"
 LABEL vendor="Red Hat, Inc."

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,14 +11,14 @@ RUN go mod download
 COPY --chown=1001 . .
 RUN ./build-syft-binary.sh
 
-FROM scratch
+FROM registry.access.redhat.com/ubi9/ubi-micro:9.3-13@sha256:d72202acf3073b61cb407e86395935b7bac5b93b16071d2b40b9fb485db2135d
 # needed for version check HTTPS request
 COPY --from=build /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem /etc/ssl/certs/ca-certificates.crt
 
 # create the /tmp dir, which is needed for image content cache
 WORKDIR /tmp
 
-COPY --from=build /src/syft/dist/syft /syft
+COPY --from=build /src/syft/dist/syft /usr/local/bin/syft
 
 LABEL org.opencontainers.image.title="syft"
 LABEL org.opencontainers.image.description="CLI tool and library for generating a Software Bill of Materials from container images and filesystems"
@@ -38,4 +38,4 @@ LABEL vendor="Red Hat, Inc."
 LABEL url="https://github.com/redhat-appstudio/rh-syft"
 LABEL distribution-scope="public"
 
-ENTRYPOINT ["/syft"]
+ENTRYPOINT ["/usr/local/bin/syft"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,8 +12,8 @@ COPY --chown=1001 . .
 RUN ./build-syft-binary.sh
 
 FROM registry.access.redhat.com/ubi9/ubi-micro:9.3-13@sha256:d72202acf3073b61cb407e86395935b7bac5b93b16071d2b40b9fb485db2135d
-# needed for version check HTTPS request
-COPY --from=build /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem /etc/ssl/certs/ca-certificates.crt
+
+ENV SYFT_CHECK_FOR_APP_UPDATE=false
 
 # create the /tmp dir, which is needed for image content cache
 WORKDIR /tmp


### PR DESCRIPTION
Not having a shell would make the Syft image somewhat inconvenient to use in CI. For example, the current Konflux buildah task would have to break up the sbom-syft-generate step [1] into two steps, each step would have to execute one syft command (can't use 'script').

Use the smallest Red Hat base image that has a shell.

[1]: https://github.com/redhat-appstudio/build-definitions/blob/3ef7e414efcb0e625d72ed4b025ea22ab362c60d/task/buildah/0.1/buildah.yaml#L232-L235