### PR TITLE
Avoid false positives in self-generated SBOM

### DIFF
--- a/.syft/config.yaml
+++ b/.syft/config.yaml
@@ -1,0 +1,2 @@
+exclude:
+- "**/test-fixtures"

--- a/hack/lib.sh
+++ b/hack/lib.sh
@@ -65,7 +65,7 @@ function get_last_release() {
 
 function apply_midstream_changes() {
     local midstream_ref=$1
-    local custom_files=(Dockerfile build-syft-binary.sh)
+    local custom_files=(Dockerfile build-syft-binary.sh .syft/)
     git checkout "$midstream_ref" -- "${custom_files[@]}"
     git add "${custom_files[@]}"
 }


### PR DESCRIPTION
The Syft tests include many package files. Syft reports the packages (used only as unit test data) in the SBOM. Exclude them.

Tested on the redhat-latest branch with

    dist/syft . -o cyclonedx-json 2>/dev/null |
    jq '.components[].purl | try match("pkg:[^/]*").string catch "<no purl>"' |
    sort | uniq -c | sort -n

Before:

      1 "pkg:rpm"
      2 "pkg:ebuild"
      2 "pkg:github"
      2 "pkg:nix"
      2 "pkg:otp"
      4 "pkg:composer"
     10 "pkg:swift"
     13 "pkg:cargo"
     13 "pkg:pub"
     14 "<no purl>"
     20 "pkg:conan"
     28 "pkg:nuget"
     39 "pkg:pypi"
     44 "pkg:hex"
     46 "pkg:cocoapods"
     54 "pkg:generic"
     55 "pkg:hackage"
     57 "pkg:maven"
     57 "pkg:npm"
    109 "pkg:gem"
    424 "pkg:golang"

After:

    408 "pkg:golang"