### PR TITLE
feat(KONFLUX-7125): Change buildah task to use overlay2 storage driver

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN go mod download
 COPY . .
 RUN ./build-syft-binary.sh
 
-FROM registry.access.redhat.com/ubi9/ubi-micro:9.4-15@sha256:7f376b75faf8ea546f28f8529c37d24adcde33dca4103f4897ae19a43d58192b
+FROM quay.io/konflux-ci/tekton-catalog/task-buildah@sha256:9ccddd19868ab459b0368af00ec823c82277b684928f18f3d18769a9f5353d12
 
 ENV SYFT_CHECK_FOR_APP_UPDATE=false
 


### PR DESCRIPTION
Modify the dockerfile (using quay.io/konflux-ci/tekton-catalog/task-buildah image as base image) so that "buildah mount $container" which supply "syft" with the container file path can be executed in the syft image. 

The new syft image would allow that the buildah-remote-oci-ta is able to build images with the overlay2 storage driver.See the PR[1]. 

[1] https://github.com/konflux-ci/build-definitions/pull/2074.